### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.with_attached_image.order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -164,40 +164,20 @@
     <li class='list'>
       <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         </div>
           
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
+            商品を出品してね！</h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span>99999999円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
              </div>
            </div>
          </div>
-      <% end %>
-    </li>
-      
-
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
       <% end %>
     </li>
   <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,20 +127,46 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      
+     <% if @items.any? %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <% if item.image.attached? %>
+            <%= image_tag item.image, class: "item-img" %>
+          <% else %>
+            <%= image_tag "item-sample.png", class: "item-img" %>
+          <% end %>
           
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+
+          <%# ★「sold out」は購入機能実装後にここで条件表示します %>
+          <%# <div class='sold-out'>
+            <span>Sold Out!!</span></div> %>
+      </div>
+
+      <div class='item-info'>
+          <h3 class='item-name'><%= item.name %></h3>
+          <div class='item-price'>
+            <span>
+              <%= number_to_currency(item.price, unit: "¥", precision: 0, format: "%u%n") %><br>
+              <%= item.delivery_fee.name %>
+            </span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
           </div>
-          
-
         </div>
+      <% end %>
+      </li>
+    <% end %>
+  <% else %>
+    <li class='list'>
+      <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag "item-sample.png", class: "item-img" %>
+        </div>
+          
         <div class='item-info'>
           <h3 class='item-name'>
             <%= "商品名" %>
@@ -150,11 +176,11 @@
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+             </div>
+           </div>
+         </div>
+      <% end %>
+    </li>
       
 
       <li class='list'>
@@ -172,12 +198,11 @@
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
-      
-    </ul>
-  </div>
-  
+      <% end %>
+    </li>
+  <% end %>
+ </ul> 
+
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>


### PR DESCRIPTION
## What
- トップページに商品一覧を表示
  - `ItemsController#index` で `@items = Item.with_attached_image.order(created_at: :desc)`
  - `app/views/items/index.html.erb` に一覧描画を実装
  - 画像・商品名・価格・配送料の負担を表示
  - 画像未登録でもリンク切れにならないようサンプル画像をフォールバック
  - 商品が0件のときはダミー2件を表示
  - 「sold out」は購入機能実装後に対応予定（要件どおり保留）

## Why
- ログイン有無に関わらず誰でも一覧を見られるようにし、要件の
  - 新しい順表示
  - 画像・商品名・価格・配送料の負担の表示
  - データ0件時のダミー表示
  を満たすため

## 動作確認（Gyazo）
- [動画] **商品のデータがない場合は、ダミー商品が表示されている**  
  https://gyazo.com/19c6bd099fcb61b94c0ad2b6a523c7be
- [動画] **商品のデータがある場合は、2件以上が新しい順で表示されている（左上が最新）**  
  https://gyazo.com/0603c3a9fc24def1dcf7916305fc8b3e

## 補足
- 「sold out」バッジは商品購入機能で実装します（現時点では未実装でも可の要件）。

## その他
- RuboCop 実行済み