### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,13 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_item, only: [:show]
 
   def index
     @items = Item.with_attached_image.order(created_at: :desc)
+  end
+
+  def show
+    
   end
 
   def new
@@ -19,6 +24,10 @@ class ItemsController < ApplicationController
   end
 
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,14 +130,14 @@
      <% if @items.any? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <% if item.image.attached? %>
             <%= image_tag item.image, class: "item-img" %>
           <% else %>
             <%= image_tag "item-sample.png", class: "item-img" %>
           <% end %>
-          
+        
 
           <%# ★「sold out」は購入機能実装後にここで条件表示します %>
           <%# <div class='sold-out'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,111 +1,112 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
+
 <div class="item-show">
   <div class="item-box">
-    <h2 class="name">
-      <%= "商品名" %>
-    </h2>
+    <h2 class="name"><%= @item.name %></h2>
+
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.image.attached? %>
+        <%= image_tag @item.image, class: "item-box-img" %>
+      <% else %>
+        <%= image_tag "item-sample.png", class: "item-box-img" %>
+      <% end %>
+
+      <%# 商品が売れている場合は、sold outを表示（購入機能で実装） %>
+      <%#
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      %>
     </div>
+
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= number_to_currency(@item.price, unit: "¥", precision: 0, format: "%u %n") %>
       </span>
-      <span class="item-postage">
-        <%= "配送料負担" %>
-      </span>
+      <span class="item-postage"><%= @item.delivery_fee.name %></span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
+    <% if user_signed_in? %>
+      <% if current_user == @item.user %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+      <% end %>
+    <% end %>
+    <%# 売却済み時は編集/削除/購入ボタンは非表示（購入機能後に実装） %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span>商品説明</span>
+      <p><%= simple_format(@item.description) %></p>
     </div>
+
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>
+
     <div class="option">
       <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <%= image_tag "star.png", class: "favorite-star-icon", width: "20", height: "20" %>
         <span>お気に入り 0</span>
       </div>
       <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <%= image_tag "flag.png", class: "report-flag-icon", width: "20", height: "20" %>
         <span>不適切な商品の通報</span>
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
+  
 
   <div class="comment-box">
     <form>
       <textarea class="comment-text"></textarea>
       <p class="comment-warn">
-        相手のことを考え丁寧なコメントを心がけましょう。
-        <br>
+        相手のことを考え丁寧なコメントを心がけましょう。<br>
         不快な言葉遣いなどは利用制限や退会処分となることがあります。
       </p>
       <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
+        <%= image_tag "comment.png", class: "comment-flag-icon", width: "20", height: "25" %>
+        <span>コメントする</span>
       </button>
     </form>
   </div>
+
   <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
+    <a href="#" class="change-item-btn">＜ 前の商品</a>
+    <a href="#" class="change-item-btn">後ろの商品 ＞</a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
## What
- show アクション追加（誰でも閲覧可）
- 一覧の各商品カードから items#show へ遷移（link_to item_path）
- 詳細ページに以下を表示
  - 商品名／画像（なければサンプル）／価格／配送料の負担
  - 商品説明／出品者名／カテゴリー／商品の状態／発送元の地域／発送日の目安
- 条件付きボタン表示（リンク先はダミー）
  - 出品者：『商品の編集』『削除』
  - 非出品者：『購入画面に進む』
  - ログアウト：いずれも非表示
- ルーティング：`resources :items, only: [:index, :new, :create, :show]`
- 「sold out」バッジは購入機能実装時に対応（補足要件）

## Why
- 要件の「誰でも詳細閲覧できる」「一覧→詳細へ遷移」「表示情報の網羅」を満たすため
- 現段階では編集/削除/購入の機能実装は対象外のため、UI の条件表示のみ実装

## Gyazo
- [動画] 一覧→詳細へ遷移できる（カードクリックで items#show）
  https://gyazo.com/71782b9aa5d5c08ae78947d08ff7efc8
  https://gyazo.com/d703444cfa4044d184f87fadf51dba23

- [動画] ログイン状態・自分の出品の詳細（編集/削除のみ表示）
  https://gyazo.com/5e4ec404631e1509c73ae4563d216d54

- [動画] ログイン状態・他人の出品の詳細（購入ボタンのみ表示）
  https://gyazo.com/69934a56bbd540351e43469e3622fc93

- [動画] ログアウト状態・詳細（ボタン非表示）
  https://gyazo.com/04762c0b150436f3809667eff273c61c