### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
-  before_action :set_item, only: [:show]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authorize_user!, only: [:edit, :update]
 
   def index
     @items = Item.with_attached_image.order(created_at: :desc)
@@ -22,10 +23,25 @@ class ItemsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to @item, notice: '商品情報を更新しました。'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def authorize_user!
+    redirect_to root_path, alert: '権限がありません。' unless current_user == @item.user
   end
 
   def item_params

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,151 +1,147 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
+
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
   </header>
+
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= form_with model: @item, local: true do |f| %>
+      <%= render 'shared/error_messages', model: f.object %>
 
-    <%# 商品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        商品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          商品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <div class="click-upload">
+          <p>クリックしてファイルをアップロード（未選択なら現在の画像のまま）</p>
+          <%= f.file_field :image, id: "item-image", accept: "image/*" %>
+        </div>
       </div>
-    </div>
-    <%# /商品名と商品説明 %>
 
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
+      
+      <div class="new-items">
         <div class="weight-bold-text">
-          カテゴリー
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
+        <%= f.text_field :name, class: "items-text", id: "item-name",
+              placeholder: "商品名（必須 40文字まで）", maxlength: 40 %>
 
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :description, class: "items-text", id: "item-info",
+                placeholder: "商品の説明（必須 1,000文字まで）",
+                rows: 7, maxlength: 1000 %>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
+      
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :category_id, Category.all, :id, :name, {},
+                { class: "select-box", id: "item-category" } %>
+
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :condition_id, Condition.all, :id, :name, {},
+                { class: "select-box", id: "item-sales-status" } %>
+        </div>
+      </div>
+
+      
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :delivery_fee_id, DeliveryFee.all, :id, :name, {},
+                { class: "select-box", id: "item-shipping-fee-status" } %>
+
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :area_id, Area.all, :id, :name, {},
+                { class: "select-box", id: "item-prefecture" } %>
+
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :shipping_day_id, ShippingDay.all, :id, :name, {},
+                { class: "select-box", id: "item-scheduled-delivery" } %>
+        </div>
+      </div>
+
+      
+      <div class="sell-price" data-controller="price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.number_field :price, id: "item-price", class: "price-input",
+                  placeholder: "例）300", min: 300, max: 9_999_999, step: 1,
+                  data: { action: "input->price#recalc" } %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span><span id="add-tax-price" data-price-target="fee"></span>円</span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span><span id="profit" data-price-target="profit"></span>円</span>
+          </div>
+        </div>
+      </div>
+
+      
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a><a href="#">行為</a>を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして<a href="#">加盟店規約</a>に同意したことになります。
+        </p>
+      </div>
+
+      
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する", class: "sell-btn" %>
+        <%= link_to "もどる", item_path(@item), class: "back-btn" %>
+      </div>
+    <% end %>
   </div>
-  <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">
@@ -153,9 +149,7 @@ app/assets/stylesheets/items/new.css %>
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-    <p class="inc">
-      ©︎Furima,Inc.
-    </p>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
+    <p class="inc">©︎Furima,Inc.</p>
   </footer>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
     
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: { turbo_method: :delete }, class: "item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
## What

edit / update を実装（出品者のみ編集可）

一覧→詳細→編集の遷移を実装（詳細の「商品の編集」は出品者にのみ表示）

画像未選択で更新しても既存画像は保持（ActiveStorage デフォルト挙動）

エラーハンドリング（保存失敗時は編集画面に戻してメッセージ表示／入力値は保持）

アクセス制御

未ログイン：編集URL直打ち→ログインページへ

ログイン済み・他人の商品：編集URL直打ち→トップへ

ルーティング：resources :items, only: [:index, :new, :create, :show, :edit, :update]

## Why

「商品情報を編集できる」「適切なアクセス制御」「エラー時の挙動」の要件を満たすため

画像更新は任意のため、未選択時に画像が消えない UX を担保

## 実装メモ

Controller

before_action :authenticate_user!, only: [:new, :create, :edit, :update]

before_action :set_item, :authorize_owner!, only: [:edit, :update]

失敗時 render :edit, status: :unprocessable_entity

View

form_with model: @item（エラー時に入力値を保持）

エラー表示は render 'shared/error_messages', model: f.object

「もどる」＝link_to item_path(@item)

補足：売却済み商品の編集不可／SOLD OUT 表示は購入機能実装時に対応（教材の補足要件に準拠）

## Gyazo

[動画] ログイン状態の出品者は、商品情報編集ページに遷移できる
https://gyazo.com/4a4786f2dbae0e7634423a7113555324

[動画] 必要な情報を適切に入力して「変更/更新する」で商品の情報を編集できる
https://gyazo.com/0f9a0a8467dd5b98cc927183f10450e6

https://gyazo.com/e2095e607cdc91b481eab9d32398116e

[動画] 入力に問題がある状態で「変更/更新する」を押すと、保存されず編集ページに戻りエラーメッセージ表示
https://gyazo.com/a0a9dca6b41153b4b23f07647cb6cbba

[動画] 何も編集せずに「変更/更新する」を押しても、画像無しの商品にならない
https://gyazo.com/71136789003a65b2c54467411eeeaf83

[動画] ログイン状態で他人商品の編集URLを直打ち→トップページへ遷移
https://gyazo.com/79f3c77fe882d7f6db182033e4b85923

[動画] ログアウト状態で編集URLを直打ち→ログインページへ遷移
https://gyazo.com/26327c2038dd04fa8b5614164ffc7c30

[動画] 編集画面に既存の「商品名/カテゴリー/状態/地域/日数/価格/説明」が表示されている
https://gyazo.com/e3ad542820b8c1c4f32000cd5aa8bf45

## 動作確認

RuboCop 実行済み（自動整形・Lint 解消）